### PR TITLE
Bootstrapped the public section

### DIFF
--- a/src/Pages/Public/PublicShell.tsx
+++ b/src/Pages/Public/PublicShell.tsx
@@ -1,0 +1,38 @@
+import React, { FC, useEffect, useState } from 'react';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { CompetitionI } from '../../models/competition.model';
+import { apiGet } from '../../Services/Api/api';
+
+export interface PublicOutletContext {
+  competition: CompetitionI;
+}
+
+const PublicShell: FC = () => {
+  // load the competition from the slug
+  const { slug } = useParams();
+  const [competition, setCompetition] = useState<CompetitionI | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    apiGet(`v2/competitions/find/${slug}`).then(
+      (res) => {
+        setCompetition(res);
+      },
+      () => {
+        // there was an error
+        navigate('/');
+      }
+    );
+  }, [slug]);
+
+  if (competition === null) {
+    return <>Caricamento in corso...</>;
+  }
+  const context: PublicOutletContext = {
+    competition
+  };
+
+  return <Outlet context={context}></Outlet>;
+};
+
+export default PublicShell;

--- a/src/Pages/Public/PublicTournaments.tsx
+++ b/src/Pages/Public/PublicTournaments.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from 'react';
+import { useOutletContext } from 'react-router-dom';
+import { PublicOutletContext } from './PublicShell';
+
+const PublicTournaments: FC = () => {
+  const { competition } = useOutletContext<PublicOutletContext>();
+
+  return <>{competition.name}</>;
+};
+
+export default PublicTournaments;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,8 @@ import CompetitionManagementPage from './Pages/CompetitionManagement/Competition
 import Tournament from './Pages/Tournament/Tournament';
 import MainLayout from './Components/Layout/MainLayout';
 import TournamentPage from './Pages/Tournament/TournamentPage';
+import PublicTournament from './Pages/Public/PublicTournaments';
+import PublicShell from './Pages/Public/PublicShell';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -32,6 +34,10 @@ root.render(
             <Route path='*' element={
               <div className='text-xl'>Page not found</div>
             } />
+            <Route path=':slug' element={<PublicShell />} >
+              <Route index element={<PublicTournament />} />
+            </Route>
+
           </Route>
           <Route path='/match-timer' element={<MatchTimer />}>
             <Route path=':matchId' element={<MatchTimer />} />


### PR DESCRIPTION
Added a new route to contain the public section
The route loads a shell, which extracts the slug from the URL params and loads the data related to the competition
The loaded competition is provided as to the child components through an OutletContext